### PR TITLE
fix(buffers): handle hydrating buffers on a new project

### DIFF
--- a/lua/multiverse/buffers.lua
+++ b/lua/multiverse/buffers.lua
@@ -78,15 +78,18 @@ M.saveAll = function()
 end
 
 M.hydrate = function()
-	log("hydrating from location: " .. getCurrentBufferFileLocation())
+	local currentBufferFileLocation = getCurrentBufferFileLocation()
 
-	local lines = io.lines(getCurrentBufferFileLocation())
+	log("hydrating from location: " .. currentBufferFileLocation)
 
-	if lines ~= nil then
-		for bufferFileLocation in lines do
+	local buffer = io.open(currentBufferFileLocation)
+
+	if buffer ~= nil then
+		for bufferFileLocation in buffer:lines() do
 			log("hydrating buffer from" .. bufferFileLocation)
 			vim.api.nvim_command("edit " .. bufferFileLocation)
 		end
+		buffer:close()
 	else
 		log("Found no lines when trying to hdrate windows")
 	end


### PR DESCRIPTION
```
this will properly check if the buffer exists before attempting to pull lines, this was previously causing an error during startup of a new project.
```

Fixes #12