### PR TITLE
feat(listeners): listen for file open / close

### DIFF
--- a/lua/multiverse.lua
+++ b/lua/multiverse.lua
@@ -1,8 +1,10 @@
 local Workspaces = require("integrations.workspaces")
+local Listeners = require("multiverse.listeners")
 local Multiverse = {}
 
 Multiverse.setup = function(config)
 	Workspaces.registerHooks()
+	Listeners.register()
 end
 
 return Multiverse

--- a/lua/multiverse/buffers.lua
+++ b/lua/multiverse/buffers.lua
@@ -66,9 +66,13 @@ M.saveAll = function()
 	local buffers = vim.api.nvim_list_bufs()
 
 	for _, buffer in ipairs(buffers) do
-		if vim.api.nvim_buf_is_loaded(buffer) then
+		if
+			vim.api.nvim_buf_is_loaded(buffer)
+			and vim.api.nvim_buf_is_valid(buffer)
+			and vim.api.nvim_buf_get_option(buffer, "modifiable")
+		then
 			local filename = vim.api.nvim_buf_get_name(buffer)
-			log("workspace: " .. currentWorkspace .. ", saving buffer: " .. filename)
+			log("workspace: " .. currentWorkspace .. ", saving buffer: " .. vim.inspect(filename))
 			if vim.fn.filereadable(filename) == 1 then
 				bufferFile:write(filename .. "\n")
 			end

--- a/lua/multiverse/listeners.lua
+++ b/lua/multiverse/listeners.lua
@@ -1,0 +1,27 @@
+local workspace = require("multiverse.workspace")
+
+local M = {}
+
+M.onFileOpened = function()
+	workspace.save()
+end
+
+M.onFileClosed = function()
+	-- todo(mikol): is there a better way to wait for the buffer marked for deletion to actually be deleted?
+	vim.defer_fn(workspace.save, 10)
+end
+
+M.register = function()
+	vim.api.nvim_exec(
+		[[
+augroup multiverse
+autocmd!
+autocmd BufRead * lua require("multiverse.listeners").onFileOpened()
+autocmd BufDelete * lua require("multiverse.listeners").onFileClosed()
+augroup END
+]],
+		false
+	)
+end
+
+return M


### PR DESCRIPTION
save the state of the workspace when files are opened and closed rather than only on workspace change.

Fixes #14