### PR TITLE
fix(dehydration): don't allocate nil windows

### DIFF
--- a/lua/multiverse/factory/window_layout_factory.lua
+++ b/lua/multiverse/factory/window_layout_factory.lua
@@ -69,10 +69,10 @@ M.make = function(neovimWindowLayout, universe)
 
 			if window ~= nil then
 				windowUuid = window.uuid
+        local leaf = Leaf:new(windowUuid, windowId)
+        node.cursor:addChild(leaf)
 			end
 
-			local leaf = Leaf:new(windowUuid, windowId)
-			node.cursor:addChild(leaf)
 		end
 	end
 

--- a/lua/multiverse/managers/window_layout_manager.lua
+++ b/lua/multiverse/managers/window_layout_manager.lua
@@ -7,7 +7,6 @@ local window_layout_factory = require("multiverse.factory.window_layout_factory"
 --- @return WindowLayout
 M.getWindowLayout = function(tabpageId, universe)
 	local layout = vim.fn.winlayout(tabpageId)
-	vim.notify(vim.inspect(layout))
 	return window_layout_factory.make(layout, universe)
 end
 


### PR DESCRIPTION
previously, we would omit the buffer uuid and save a window
this caused orphaned windows to create new entries in
the universe on every save.

by omitting orphaned windows, this problem is solved.

Fixes https://github.com/codymikol/multiverse.nvim/issues/61