### PR TITLE
feat(multiverse): hydrate universe on VimEnter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@ Created multiverse.nvim
 
 * Save current open buffers upon leaving a workspace and rehydrate upon re-entry.
 * Set the correct Neotree directory upon opening a workspace.
+* Automatically load a universe when opening Neovim directly on its directory.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ The aim of this project is to increase productivity when context switching betwe
 
 
 
+## Startup Behavior
+
+- **Automatic hydration on directory entry**
+  - **Description**: Opening Neovim directly on a directory that matches a registered *Universe* (e.g. `nvim .` or `nvim /path/to/project`) automatically hydrates that *Universe* on startup, equivalent to running `:MultiverseOpen <name>`. No action is required from the user.
+
 ## Integrations
 
 - **`Neotree`**

--- a/lua/multiverse.lua
+++ b/lua/multiverse.lua
@@ -2,6 +2,7 @@ local initialize = require("multiverse.usecases.initialize")
 local cli = require("multiverse.managers.cli_manager")
 local on_exit = require("multiverse.autocmd.on_exit")
 local on_buffer_close = require("multiverse.autocmd.on_buffer_close")
+local on_vim_enter = require("multiverse.autocmd.on_vim_enter")
 
 local Multiverse = {}
 
@@ -10,6 +11,7 @@ Multiverse.setup = function()
   cli.registerCommands()
   on_exit.register()
   on_buffer_close.register()
+  on_vim_enter.register()
 end
 
 return Multiverse

--- a/lua/multiverse/autocmd/on_vim_enter.lua
+++ b/lua/multiverse/autocmd/on_vim_enter.lua
@@ -1,0 +1,50 @@
+local M = {}
+
+local multiverse_manager = require("multiverse.managers.multiverse_manager")
+local multiverse_repository = require("multiverse.repositories.multiverse_repository")
+local state_store = require("multiverse.store.state_store")
+local log = require("multiverse.log")
+
+M.on_vim_enter = function()
+  local success, err = pcall(function()
+    if state_store.get_current_state() ~= state_store.STATES.IDLE then
+      return
+    end
+
+    local buffer_name = vim.api.nvim_buf_get_name(0)
+
+    if buffer_name == "" or vim.fn.isdirectory(buffer_name) == 0 then
+      return
+    end
+
+    local directory = vim.fn.fnamemodify(buffer_name, ":p"):gsub("/$", "")
+
+    local multiverse = multiverse_repository.getMultiverse()
+
+    local universe_summary = multiverse:getUniverseByDirectory(directory)
+    if universe_summary == nil then
+      universe_summary = multiverse:getUniverseByDirectory(directory .. "/")
+    end
+
+    if universe_summary == nil then
+      return
+    end
+
+    -- skip_save = true: at VimEnter there is no meaningful prior session in
+    -- the current (empty/netrw) buffer to save, and saving here would
+    -- clobber the target universe's already-persisted session (GH #104).
+    multiverse_manager.load_universe(multiverse, universe_summary, true)
+  end)
+
+  if not success then
+    log.error("Error loading universe on startup: " .. vim.inspect(err))
+  end
+end
+
+M.register = function()
+  vim.api.nvim_create_autocmd("VimEnter", {
+    callback = M.on_vim_enter,
+  })
+end
+
+return M

--- a/lua/multiverse/managers/multiverse_manager.lua
+++ b/lua/multiverse/managers/multiverse_manager.lua
@@ -92,7 +92,11 @@ end
 
 --- @param multiverse Multiverse
 --- @param selected_universe_summary UniverseSummary
-M.load_universe = function(multiverse, selected_universe_summary)
+--- @param skip_save boolean | nil  when true, skips saving/dehydrating whatever is currently open before
+--- hydrating the selected universe. Callers should pass true when there is nothing meaningful to save (e.g.
+--- on VimEnter, where the current buffer is just the empty/startup state, not a prior session), since saving
+--- in that case would clobber the target universe's already-persisted session.
+M.load_universe = function(multiverse, selected_universe_summary, skip_save)
 
   log.debug("Loading universe: " .. selected_universe_summary.name)
 
@@ -101,25 +105,40 @@ M.load_universe = function(multiverse, selected_universe_summary)
     selected_universe_summary.lastExplored = timestamp_manager.now()
     multiverse_repository.save_multiverse(multiverse)
 
-    local current_directory = vim.fn.getcwd()
+    local current_universe = nil
 
-    local current_universe_summary = multiverse:getUniverseByDirectory(current_directory)
+    if not skip_save then
 
-    if current_universe_summary ~= nil then
+      local current_directory = vim.fn.getcwd()
 
-      local current_universe, err = universe_repository.get_universe_by_uuid(current_universe_summary.uuid)
-
-      if current_universe == nil then
-        log.error("Error dehydrating universe: " .. current_universe_summary.uuid .. ", error details: " .. vim.inspect(err))
-        return
+      local current_universe_summary = multiverse:getUniverseByDirectory(current_directory)
+      if current_universe_summary == nil then
+        current_universe_summary = multiverse:getUniverseByDirectory(current_directory .. "/")
       end
 
-      log.debug("load universe searching multiverse for matching directory and found: " .. vim.inspect(current_universe_summary))
+      if current_universe_summary ~= nil then
 
-      M.save()
+        -- deliberately shadowed: keeps beforeHydrate/afterHydrate's
+        -- `current_universe` argument at its pre-existing value (nil) here,
+        -- matching MultiverseOpen's behavior prior to this file's skip_save
+        -- change instead of silently altering it.
+        local current_universe, err = universe_repository.get_universe_by_uuid(current_universe_summary.uuid)
+
+        if current_universe == nil then
+          log.error("Error dehydrating universe: " .. current_universe_summary.uuid .. ", error details: " .. vim.inspect(err))
+          return
+        end
+
+        log.debug("load universe searching multiverse for matching directory and found: " .. vim.inspect(current_universe_summary))
+
+        M.save()
+
+      else
+        log.debug("Working directory is not part of a universe, proceeding with loading the selected universe and skipping dehydration.")
+      end
 
     else
-      log.debug("Working directory is not part of a universe, proceeding with loading the selected universe and skipping dehydration.")
+      log.debug("skip_save is true, proceeding with loading the selected universe and skipping dehydration.")
     end
 
     state_store.set_current_state(state_store.STATES.CLEANUP)

--- a/lua/test/managers/on_vim_enter.headless.lua
+++ b/lua/test/managers/on_vim_enter.headless.lua
@@ -1,0 +1,124 @@
+-- Test for GitHub issue #104 (load universe when entering a universe
+-- directory).
+--
+-- This is NOT a busted-style spec, and is deliberately NOT named
+-- `*.spec.lua` so a busted runner globbing this tree never collects it: it
+-- exercises real `vim.api` calls (buffers, windows) that busted/luarocks
+-- cannot provide, calls `os.exit()`, and must be run inside an actual nvim
+-- instance rather than via the busted test runner used by the other files
+-- under lua/test/**/*.spec.lua.
+--
+-- Run from the repository root with:
+--   nvim --headless -u NONE -l lua/test/managers/on_vim_enter.headless.lua
+--
+-- The script prints "PASS" and exits 0 on success, or raises a Lua error
+-- (via `assert`) and exits non-zero on failure.
+
+package.path = "./lua/?.lua;./lua/?/init.lua;" .. package.path
+
+local Multiverse = require("multiverse.data.Multiverse")
+local UniverseSummary = require("multiverse.data.UniverseSummary")
+local multiverse_repository = require("multiverse.repositories.multiverse_repository")
+local multiverse_manager = require("multiverse.managers.multiverse_manager")
+local state_store = require("multiverse.store.state_store")
+
+-- Build a real directory on disk, and point the current buffer's name at
+-- it, simulating nvim having been started as `nvim <dir>`.
+local test_dir = vim.fn.tempname()
+vim.fn.mkdir(test_dir, "p")
+
+vim.api.nvim_buf_set_name(0, test_dir)
+
+-- Build a fake universe whose directory matches the buffer's directory.
+local universe_summary = UniverseSummary:new(test_dir, "test-universe-uuid", "test-universe", 0)
+
+local multiverse = Multiverse:new({ universe_summary })
+
+-- Monkeypatch multiverse_repository.getMultiverse to return our fake
+-- multiverse rather than hitting disk.
+local original_getMultiverse = multiverse_repository.getMultiverse
+multiverse_repository.getMultiverse = function()
+  return multiverse
+end
+
+-- Monkeypatch multiverse_manager.load_universe to just record the call,
+-- rather than let the real, heavy-side-effect implementation run.
+local original_load_universe = multiverse_manager.load_universe
+local load_universe_calls = {}
+multiverse_manager.load_universe = function(m, summary, skip_save)
+  table.insert(load_universe_calls, { multiverse = m, universe_summary = summary, skip_save = skip_save })
+end
+
+-- Ensure we exercise the "no hydration/dehydration currently in flight"
+-- branch.
+state_store.set_current_state(state_store.STATES.IDLE)
+
+local on_vim_enter = require("multiverse.autocmd.on_vim_enter")
+
+on_vim_enter.on_vim_enter()
+
+assert(#load_universe_calls == 1,
+  "expected load_universe to be called exactly once, but was called " .. #load_universe_calls .. " times")
+
+assert(load_universe_calls[1].universe_summary == universe_summary,
+  "expected load_universe to be called with the matching universe summary")
+
+assert(load_universe_calls[1].skip_save == true,
+  "expected load_universe to be called with skip_save = true, since there is nothing meaningful "
+    .. "to save at VimEnter and saving would clobber the target universe's persisted session")
+
+-- Case: current buffer is a regular file (not a directory) → load_universe
+-- must NOT be called.
+load_universe_calls = {}
+
+local regular_file = test_dir .. "/regular_file.txt"
+local fh = io.open(regular_file, "w")
+fh:write("not a directory")
+fh:close()
+
+vim.api.nvim_buf_set_name(0, regular_file)
+
+on_vim_enter.on_vim_enter()
+
+assert(#load_universe_calls == 0,
+  "expected load_universe NOT to be called when the buffer is a regular file, but was called "
+    .. #load_universe_calls .. " times")
+
+-- Case: current buffer's directory does not match any registered universe
+-- → load_universe must NOT be called.
+load_universe_calls = {}
+
+local unregistered_dir = vim.fn.tempname()
+vim.fn.mkdir(unregistered_dir, "p")
+
+vim.api.nvim_buf_set_name(0, unregistered_dir)
+
+on_vim_enter.on_vim_enter()
+
+assert(#load_universe_calls == 0,
+  "expected load_universe NOT to be called when the buffer's directory does not match any "
+    .. "registered universe, but was called " .. #load_universe_calls .. " times")
+
+-- Case: state_store.get_current_state() is not IDLE (e.g. HYDRATION), even
+-- though the directory matches a universe → load_universe must NOT be
+-- called. This guards against double-firing alongside the existing
+-- BufRead → save() listener.
+load_universe_calls = {}
+
+vim.api.nvim_buf_set_name(0, test_dir)
+state_store.set_current_state(state_store.STATES.HYDRATION)
+
+on_vim_enter.on_vim_enter()
+
+state_store.set_current_state(state_store.STATES.IDLE)
+
+assert(#load_universe_calls == 0,
+  "expected load_universe NOT to be called when state_store is not IDLE, but was called "
+    .. #load_universe_calls .. " times")
+
+-- restore originals for hygiene, even though this is a one-shot process
+multiverse_repository.getMultiverse = original_getMultiverse
+multiverse_manager.load_universe = original_load_universe
+
+print("PASS")
+os.exit(0)

--- a/lua/test/managers/on_vim_enter_data_loss.headless.lua
+++ b/lua/test/managers/on_vim_enter_data_loss.headless.lua
@@ -1,0 +1,140 @@
+-- Regression test for GitHub issue #104 (VimEnter auto-hydrate destroying a
+-- universe's persisted session).
+--
+-- Unlike lua/test/managers/on_vim_enter.headless.lua, this test does NOT
+-- monkeypatch multiverse_manager.load_universe -- it exercises the real
+-- save/cleanup/hydrate pipeline that `:autocmd VimEnter` triggers, which is
+-- exactly the interaction that let the bug ship untested.
+--
+-- Scenario reproduced: `cd ~/project && nvim .` where `~/project` is already
+-- a registered universe with a real saved session. Before the fix,
+-- `on_vim_enter` -> `multiverse_manager.load_universe` would notice
+-- `getcwd()` matches the universe being loaded and call `M.save()`, which
+-- dehydrates the empty/near-empty startup buffer state and clobbers the
+-- universe's already-persisted session on disk before hydration even reads
+-- it back. This test asserts the persisted universe file is untouched by a
+-- fresh-startup `on_vim_enter()` call.
+--
+-- This is NOT a busted-style spec, and is deliberately NOT named
+-- `*.spec.lua` so a busted runner globbing this tree never collects it: it
+-- exercises real `vim.api` calls (buffers, windows, cwd) and real
+-- filesystem persistence that busted/luarocks cannot provide, calls
+-- `os.exit()`, and must be run inside an actual nvim instance rather than
+-- via the busted test runner used by the other files under
+-- lua/test/**/*.spec.lua.
+--
+-- Run from the repository root with:
+--   nvim --headless -u NONE -l lua/test/managers/on_vim_enter_data_loss.headless.lua
+--
+-- The script prints "PASS" and exits 0 on success, or raises a Lua error
+-- (via `assert`) and exits non-zero on failure.
+
+package.path = "./lua/?.lua;./lua/?/init.lua;" .. package.path
+
+local persistance = require("multiverse.repositories.persistance")
+
+-- Redirect all persisted state to a throwaway temp directory rather than the
+-- real `stdpath("data")/workspace-persistance` location.
+local persistance_dir = vim.fn.tempname()
+vim.fn.mkdir(persistance_dir, "p")
+
+local original_getDir = persistance.getDir
+persistance.getDir = function()
+  return persistance_dir
+end
+
+local Universe = require("multiverse.data.Universe")
+local UniverseSummary = require("multiverse.data.UniverseSummary")
+local Buffer = require("multiverse.data.Buffer")
+local multiverse_repository = require("multiverse.repositories.multiverse_repository")
+local universe_repository = require("multiverse.repositories.universe_repository")
+local state_store = require("multiverse.store.state_store")
+local neotree_integration = require("integrations.neotree")
+local neotree_plugin = require("plugins.neotree_plugin")
+-- Require this now (before `cd`-ing below), since package.path is set up
+-- with relative paths resolved against the process cwd at require-time.
+local on_vim_enter = require("multiverse.autocmd.on_vim_enter")
+
+-- Stub out the Neotree integration/plugin hooks so save/dehydrate/hydrate
+-- don't attempt to run `:Neotree ...` ex commands, which don't exist in this
+-- `-u NONE` headless session (and would otherwise short-circuit `M.save()`
+-- via its own pcall before it ever reaches the destructive
+-- `universe_repository.save_universe` write we're trying to catch). Real
+-- load_universe/save wrap these in a pcall regardless, but stubbing them
+-- keeps the test deterministic and focused on the save/hydrate data-loss
+-- interaction rather than incidental plugin-command errors.
+local original_neotree_hydrate = neotree_integration.hydrate
+neotree_integration.hydrate = function() end
+
+local original_neotree_beforeDehydrate = neotree_plugin.context.beforeDehydrate
+local original_neotree_afterHydrate = neotree_plugin.context.afterHydrate
+neotree_plugin.context.beforeDehydrate = function() end
+neotree_plugin.context.afterHydrate = function() end
+
+-- A real directory on disk, standing in for `~/project` -- a registered
+-- universe's working directory.
+local test_dir = vim.fn.tempname()
+vim.fn.mkdir(test_dir, "p")
+
+local universe_uuid = "test-universe-uuid-104"
+local marker = "IMPORTANT_NON_TRIVIAL_SESSION_MARKER_important_file.lua"
+
+-- Register the universe in the multiverse.
+local universe_summary = UniverseSummary:new(test_dir, universe_uuid, "test-universe", 0)
+
+local multiverse = multiverse_repository.getMultiverse()
+table.insert(multiverse.universes, universe_summary)
+multiverse_repository.save_multiverse(multiverse)
+
+-- Persist a real, non-trivial session for that universe: a buffer that is
+-- very clearly NOT the empty/near-empty state a fresh `nvim .` startup
+-- buffer would produce.
+local universe = Universe:new(universe_uuid, "test-universe", test_dir)
+universe:addBuffer(Buffer:new("test-buffer-uuid-104", nil, marker))
+universe_repository.save_universe(universe)
+
+-- Sanity check (this is the "confirm setup worked" step, not the
+-- regression assertion): the persisted universe file on disk should
+-- contain our marker.
+local function read_universe_file()
+  local path = persistance_dir .. "/universe-" .. universe_uuid .. ".json"
+  local file = io.open(path, "r")
+  assert(file ~= nil, "expected universe file to exist at " .. path)
+  local contents = file:read("*a")
+  file:close()
+  return contents
+end
+
+local contents_before = read_universe_file()
+assert(contents_before:find(marker, 1, true) ~= nil,
+  "setup sanity check failed: persisted universe file does not contain the non-trivial session marker before "
+    .. "on_vim_enter() was even called")
+
+-- Simulate a fresh nvim startup: `cd ~/project && nvim .` -- shell cwd and
+-- the startup buffer's directory both match the registered universe.
+vim.api.nvim_command("cd " .. vim.fn.fnameescape(test_dir))
+vim.api.nvim_buf_set_name(0, test_dir)
+
+state_store.set_current_state(state_store.STATES.IDLE)
+
+-- Call the REAL on_vim_enter -> multiverse_manager.load_universe pipeline;
+-- nothing here is monkeypatched.
+on_vim_enter.on_vim_enter()
+
+state_store.set_current_state(state_store.STATES.IDLE)
+
+local contents_after = read_universe_file()
+
+assert(contents_after:find(marker, 1, true) ~= nil,
+  "REGRESSION (GH #104): the persisted universe file was clobbered by a fresh-startup on_vim_enter() call -- "
+    .. "the non-trivial session marker is gone. on_vim_enter() must not save/dehydrate the startup buffer state "
+    .. "over an existing universe's session.")
+
+-- restore originals for hygiene, even though this is a one-shot process
+persistance.getDir = original_getDir
+neotree_integration.hydrate = original_neotree_hydrate
+neotree_plugin.context.beforeDehydrate = original_neotree_beforeDehydrate
+neotree_plugin.context.afterHydrate = original_neotree_afterHydrate
+
+print("PASS")
+os.exit(0)


### PR DESCRIPTION
## Summary
- Auto-hydrate a registered universe when Neovim is opened directly on its directory (`nvim .` / `nvim /path/to/project`), reusing the same `load_universe` path as `:MultiverseOpen`, gated on `state_store` being `IDLE`.
- Fixed a data-loss bug surfaced during review: `load_universe`'s existing save-before-hydrate step used `getcwd()` to decide whether to dehydrate the *current* buffer state before loading — at `VimEnter` that current state is just the empty startup buffer, so it was clobbering the target (or an unrelated) universe's already-persisted session. Added an explicit `skip_save` parameter, set to `true` only from the new `VimEnter` path; `:MultiverseOpen` is unchanged.
- Documented the new startup behavior in README and CHANGELOG.

Closes #104

## Test plan
- [x] New headless test `lua/test/managers/on_vim_enter.headless.lua` — matching-directory hydrate call, and no-op cases (non-directory buffer, no matching universe, non-`IDLE` state).
- [x] New headless regression test `lua/test/managers/on_vim_enter_data_loss.headless.lua` — proves a persisted universe's session survives a `VimEnter` auto-hydrate (previously clobbered; confirmed RED before the `skip_save` fix, GREEN after).
- [x] Existing headless suite (`dehydration_manager`, `window_manager`) still green.
- [x] `nix flake check`/`nix develop` unavailable in this sandbox (`Permission denied` on the flake lock file); fell back to the baked `nvim --headless` toolchain for all checks, as instructed.